### PR TITLE
Target Multiple Frameworks (net462;net472;net48;netcoreapp3.1)

### DIFF
--- a/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
@@ -7,9 +7,16 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Federation;
-using System.ServiceModel.Security;
 using Microsoft.Xrm.Sdk;
 using WSFederationHttpBinding = System.ServiceModel.Federation.WSFederationHttpBinding;
+
+#if NET462_OR_GREATER
+using SecurityBindingElement = System.ServiceModel.Channels.SecurityBindingElement;
+using SecurityKeyEntropyMode = System.ServiceModel.Security.SecurityKeyEntropyMode;
+#else
+using SecurityBindingElement = SSS.System.ServiceModel.Channels.SecurityBindingElement;
+using SecurityKeyEntropyMode = SSS.System.ServiceModel.Security.SecurityKeyEntropyMode;
+#endif
 
 namespace Data8.PowerPlatform.Dataverse.Client
 {
@@ -26,23 +33,14 @@ namespace Data8.PowerPlatform.Dataverse.Client
             public ServerEntropyWS2007HttpBinding(SecurityMode securityMode) : base(securityMode)
             {
             }
-#if NET462_OR_GREATER
-            protected override System.ServiceModel.Channels.SecurityBindingElement CreateMessageSecurity()
+
+            protected override SecurityBindingElement CreateMessageSecurity()
             {
                 // Use server entropy to match SDK
                 var o = base.CreateMessageSecurity();
                 o.KeyEntropyMode = SecurityKeyEntropyMode.ServerEntropy;
                 return o;
             }
-#else
-            protected override SSS.System.ServiceModel.Channels.SecurityBindingElement CreateMessageSecurity()
-            {
-                // Use server entropy to match SDK
-                var o = base.CreateMessageSecurity();
-                o.KeyEntropyMode = SSS.System.ServiceModel.Security.SecurityKeyEntropyMode.ServerEntropy;
-                return o;
-            }
-#endif
         }
 
         /// <summary>

--- a/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
@@ -8,11 +8,13 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Federation;
 using Microsoft.Xrm.Sdk;
-using WSFederationHttpBinding = System.ServiceModel.Federation.WSFederationHttpBinding;
 
 #if NET462_OR_GREATER
+using WSFederationHttpBinding = System.ServiceModel.Federation.WSFederationHttpBinding;
+
 using SecurityBindingElement = System.ServiceModel.Channels.SecurityBindingElement;
 using SecurityKeyEntropyMode = System.ServiceModel.Security.SecurityKeyEntropyMode;
+
 #else
 using SecurityBindingElement = SSS.System.ServiceModel.Channels.SecurityBindingElement;
 using SecurityKeyEntropyMode = SSS.System.ServiceModel.Security.SecurityKeyEntropyMode;

--- a/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
@@ -7,7 +7,9 @@ using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Federation;
+using System.ServiceModel.Security;
 using Microsoft.Xrm.Sdk;
+using WSFederationHttpBinding = System.ServiceModel.Federation.WSFederationHttpBinding;
 
 namespace Data8.PowerPlatform.Dataverse.Client
 {
@@ -24,7 +26,15 @@ namespace Data8.PowerPlatform.Dataverse.Client
             public ServerEntropyWS2007HttpBinding(SecurityMode securityMode) : base(securityMode)
             {
             }
-
+#if NET462_OR_GREATER
+            protected override System.ServiceModel.Channels.SecurityBindingElement CreateMessageSecurity()
+            {
+                // Use server entropy to match SDK
+                var o = base.CreateMessageSecurity();
+                o.KeyEntropyMode = SecurityKeyEntropyMode.ServerEntropy;
+                return o;
+            }
+#else
             protected override SSS.System.ServiceModel.Channels.SecurityBindingElement CreateMessageSecurity()
             {
                 // Use server entropy to match SDK
@@ -32,6 +42,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
                 o.KeyEntropyMode = SSS.System.ServiceModel.Security.SecurityKeyEntropyMode.ServerEntropy;
                 return o;
             }
+#endif
         }
 
         /// <summary>

--- a/Data8.PowerPlatform.Dataverse.Client/Data8.PowerPlatform.Dataverse.Client.csproj
+++ b/Data8.PowerPlatform.Dataverse.Client/Data8.PowerPlatform.Dataverse.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReleaseNotes>Added support for AD authentication</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Data8/DataverseClient</PackageProjectUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>Provides a WS-Trust compatible client for connecting to on-premise IFD instances of Dynamics 365 from .NET Core.
+	  <Description>Provides a WS-Trust compatible client for connecting to on-premise IFD instances of Dynamics 365 from .NET Core.
 
 This package builds on top of Microsoft.PowerPlatform.Dataverse.Client and offers an alternative IOrganizationService implementation using WS-Trust.
 This allows you to connect using the URL of the organization service, username and password without any additional
@@ -86,7 +86,7 @@ void CreateRecord(IOrganizationService svc)
     <PackageReference Include="System.ServiceModel.Federation" Version="4.9.0" />
   </ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48'">
 		<Reference Include="System.ServiceModel" />
 	</ItemGroup>
 

--- a/Data8.PowerPlatform.Dataverse.Client/Data8.PowerPlatform.Dataverse.Client.csproj
+++ b/Data8.PowerPlatform.Dataverse.Client/Data8.PowerPlatform.Dataverse.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net462;net472;net48;netcoreapp3.1</TargetFrameworks>
     <Authors>MarkMpn,Data8 Ltd</Authors>
     <Copyright>Copyright © 2021 Data8 Limited</Copyright>
     <RepositoryUrl>https://github.com/Data8/DataverseClient</RepositoryUrl>
@@ -85,6 +85,10 @@ void CreateRecord(IOrganizationService svc)
 	<PackageReference Include="System.ServiceModel.Security" Version="4.9.0" Aliases="SSS" />
     <PackageReference Include="System.ServiceModel.Federation" Version="4.9.0" />
   </ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='net462'">
+		<Reference Include="System.ServiceModel" />
+	</ItemGroup>
 
   <ItemGroup>
     <None Include="..\Data8.png">

--- a/Data8.PowerPlatform.Dataverse.Client/OnPremiseClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/OnPremiseClient.cs
@@ -104,8 +104,8 @@ namespace Data8.PowerPlatform.Dataverse.Client
             var wsdl = Wsdl.WsdlLoader.Load(url + "?wsdl&sdkversion=" + _sdkMajorVersion).ToList();
 
             var policies = wsdl
-                .Where(wsdl => wsdl.Policies != null)
-                .SelectMany(wsdl => wsdl.Policies)
+                .Where(w => w.Policies != null)
+                .SelectMany(w => w.Policies)
                 .ToList();
 
             var authenticationPolicy = policies
@@ -120,8 +120,8 @@ namespace Data8.PowerPlatform.Dataverse.Client
             {
                 case Wsdl.AuthenticationType.ActiveDirectory:
                     var identity = wsdl
-                        .Where(wsdl => wsdl.Services != null)
-                        .SelectMany(wsdl => wsdl.Services)
+                        .Where(w => w.Services != null)
+                        .SelectMany(w => w.Services)
                         .Single()
                         .Ports
                         .Where(port => new Uri(port.Address.Location).Scheme.Equals(new Uri(url).Scheme, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
This small change allows us to use this library with multiple frameworks (net462;net472;net48;netcoreapp3.1) so it is easier to port code from legacy projects (.NET Framework 4.6.2 in my case) to the newest .NET.
This will follow the same targets as `Microsoft.PowerPlatform.Dataverse.Client`

I did a quick test in console applications, one targeting .NET Framework 4.6.2 and one .NET 6.

```C#
public static void Main(string[] args)
{
    var url = $@"https://192.168.0.100/Dev/XRMServices/2011/Organization.svc";
    var username = "user";
    var password = "p@ss";

    ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };

    try
    {
        var client = new OnPremiseClient(url, username, password);
        ListContacts(client);
    }
    catch (Exception ex)
    {
        Console.WriteLine(ex.Message);
    }
}

static void ListContacts(IOrganizationService client)
{
    var query = new QueryExpression("contact")
    {
        ColumnSet = new ColumnSet("email_address", "login"),
        PageInfo = new PagingInfo() { PageNumber = 1, Count = 500 }
    };

    var total = 0;

    EntityCollection result;
    
    do
    {
        result = client.RetrieveMultiple(query);

        foreach (var entity in result.Entities)
        {
            var email = entity.GetAttributeValue<string>("email_address");
            var login = entity.GetAttributeValue<string>("login");
            Console.WriteLine($"{login} - {email}");
        }

        query.PageInfo.PageNumber++;
        total += result.Entities.Count;

    } while (result.MoreRecords);

    Console.WriteLine($"Total: {total}");
}
```

I'm just starting with PowerPlatform, so if someone could do tests with a more advanced scenario it would really help with this PR review.