### PR TITLE
support for clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+/.runsettings

--- a/Data8.PowerPlatform.Dataverse.Client.Tests/ConnectionTests.cs
+++ b/Data8.PowerPlatform.Dataverse.Client.Tests/ConnectionTests.cs
@@ -51,6 +51,30 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         }
 
         [Fact]
+        public void CloneACloneTest()
+        {
+            var adUrl = Environment.GetEnvironmentVariable("AD_URL");
+            var adUsername = Environment.GetEnvironmentVariable("AD_USERNAME");
+            var adPassword = Environment.GetEnvironmentVariable("AD_PASSWORD");
+
+            var client = new OnPremiseClient(adUrl, adUsername, adPassword);
+            var resp = (WhoAmIResponse)client.Execute(new WhoAmIRequest());
+
+            var newClient = client.Clone();
+
+            client = null;
+
+            var resp2 = (WhoAmIResponse)newClient.Execute(new WhoAmIRequest());
+
+            Assert.Equal(resp.UserId, resp2.UserId);
+
+            var newClient2 = newClient.Clone();
+            var resp3 = (WhoAmIResponse)newClient2.Execute(new WhoAmIRequest());
+
+            Assert.Equal(resp.UserId, resp3.UserId);
+        }
+
+        [Fact]
         public void CloneTestInTasks()
         {
             var adUrl = Environment.GetEnvironmentVariable("AD_URL");

--- a/Data8.PowerPlatform.Dataverse.Client.Tests/ConnectionTests.cs
+++ b/Data8.PowerPlatform.Dataverse.Client.Tests/ConnectionTests.cs
@@ -43,7 +43,6 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
 
             var newClient = client.Clone();
 
-            client.Dispose();
             client = null;
 
             var resp2 = (WhoAmIResponse)newClient.Execute(new WhoAmIRequest());

--- a/Data8.PowerPlatform.Dataverse.Client.Tests/ConnectionTests.cs
+++ b/Data8.PowerPlatform.Dataverse.Client.Tests/ConnectionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Crm.Sdk.Messages;
 using Xunit;
 
@@ -6,6 +7,12 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
 {
     public class ConnectionTests
     {
+        public ConnectionTests()
+        {
+            //allow all certificates
+            System.Net.ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
+        }
+
         [Fact]
         public void ADTest()
         {
@@ -14,7 +21,55 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
             var adPassword = Environment.GetEnvironmentVariable("AD_PASSWORD");
 
             var client = new OnPremiseClient(adUrl, adUsername, adPassword);
-            client.Execute(new WhoAmIRequest());
+            var resp = (WhoAmIResponse)client.Execute(new WhoAmIRequest());
+
+            Assert.NotEqual(Guid.Empty, resp.UserId);
+        }
+
+        [Fact]
+        public void CloneTest()
+        {
+            var adUrl = Environment.GetEnvironmentVariable("AD_URL");
+            var adUsername = Environment.GetEnvironmentVariable("AD_USERNAME");
+            var adPassword = Environment.GetEnvironmentVariable("AD_PASSWORD");
+
+            var client = new OnPremiseClient(adUrl, adUsername, adPassword);
+            var resp = (WhoAmIResponse)client.Execute(new WhoAmIRequest());
+
+            var newClient = client.Clone();
+
+            client.Dispose();
+            client = null;
+
+            var resp2 = (WhoAmIResponse)newClient.Execute(new WhoAmIRequest());
+
+            Assert.Equal(resp.UserId, resp2.UserId);
+        }
+
+        [Fact]
+        public void CloneTestInTasks()
+        {
+            var adUrl = Environment.GetEnvironmentVariable("AD_URL");
+            var adUsername = Environment.GetEnvironmentVariable("AD_USERNAME");
+            var adPassword = Environment.GetEnvironmentVariable("AD_PASSWORD");
+
+            var client = new OnPremiseClient(adUrl, adUsername, adPassword);
+            var resp = (WhoAmIResponse)client.Execute(new WhoAmIRequest());
+
+            var tasks = new Task[100];
+            //in each task clone the client and execute a whoami request
+            for (var i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    var newClient = client.Clone();
+                    var resp2 = (WhoAmIResponse)newClient.Execute(new WhoAmIRequest());
+                    Assert.Equal(resp.UserId, resp2.UserId);
+                });
+            }
+
+            //await all tasks
+            Task.WaitAll(tasks);
         }
 
         [Fact]

--- a/Data8.PowerPlatform.Dataverse.Client.sln
+++ b/Data8.PowerPlatform.Dataverse.Client.sln
@@ -1,16 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31321.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33530.505
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Data8.PowerPlatform.Dataverse.Client", "Data8.PowerPlatform.Dataverse.Client\Data8.PowerPlatform.Dataverse.Client.csproj", "{0CA91220-636E-4861-9F64-EC378AC9BE51}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{865CF121-C8A3-4C81-94F1-988623BB9287}"
 	ProjectSection(SolutionItems) = preProject
+		.runsettings = .runsettings
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Data8.PowerPlatform.Dataverse.Client.Tests", "Data8.PowerPlatform.Dataverse.Client.Tests\Data8.PowerPlatform.Dataverse.Client.Tests.csproj", "{66B5C62D-A949-4704-876A-3DF60006C705}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Data8.PowerPlatform.Dataverse.Client.Tests", "Data8.PowerPlatform.Dataverse.Client.Tests\Data8.PowerPlatform.Dataverse.Client.Tests.csproj", "{66B5C62D-A949-4704-876A-3DF60006C705}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Data8.PowerPlatform.Dataverse.Client/OnPremiseClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/OnPremiseClient.cs
@@ -24,7 +24,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
     /// <remarks>
     /// Claims-based authentication, IFD and Active Directory authentication are all supported.
     /// </remarks>
-    public class OnPremiseClient : IOrganizationServiceAsync2, IDisposable
+    public class OnPremiseClient : IOrganizationServiceAsync2
     {
         /// <summary>
         /// Adds headers into the SOAP requests
@@ -517,33 +517,5 @@ namespace Data8.PowerPlatform.Dataverse.Client
                 return _service.RetrieveMultipleAsync(query);
             }
         }
-
-        #region IDisposable Support
-
-        private bool isDisposed; // To detect redundant calls
-
-        private void Dispose(bool disposing)
-        {
-            if (!isDisposed)
-            {
-                if (disposing)
-                {
-                    _innerService = null;
-                    _service = null;
-                }
-                isDisposed = true;
-            }
-        }
-
-
-        /// <summary>
-        /// Disposed the resources used by the ServiceClient.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-        #endregion
     }
 }


### PR DESCRIPTION
This adds support for Clone - this will create a new client without the need to do extra requests to get WSDL definitions (which can take significant amount of time).
I've added support for IDisposable to OnPremiseClient, so we can dispose the object (I'm not sure if we need to dispose any internal resources)
I've cleaned LINQ to remove extra methods, for example I use SingleOfDefault instead of Where and SingleOfDefault.

