### PR TITLE
Async

### DIFF
--- a/Data8.PowerPlatform.Dataverse.Client.Tests/AdAuthClientTests.cs
+++ b/Data8.PowerPlatform.Dataverse.Client.Tests/AdAuthClientTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
 using Xunit;
 using Xunit.Abstractions;
+using AuthenticationType = Data8.PowerPlatform.Dataverse.Client.Wsdl.AuthenticationType;
 
 namespace Data8.PowerPlatform.Dataverse.Client.Tests
 {
@@ -32,6 +33,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         public void WhoAmIRequestTest()
         {
             var client = new OnPremiseClient(AdUrl, AdUsername, AdPassword);
+            Assert.Equal(AuthenticationType.ActiveDirectory, client.AuthenticationType);
             var response = client.Execute(new WhoAmIRequest()) as WhoAmIResponse;
 
             Assert.NotNull(response);
@@ -42,6 +44,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         public void CloneTest()
         {
             var client = new OnPremiseClient(AdUrl, AdUsername, AdPassword);
+            Assert.Equal(AuthenticationType.ActiveDirectory, client.AuthenticationType);
             var response1 = client.Execute(new WhoAmIRequest()) as WhoAmIResponse;
             var newClient = client.Clone();
             client = null;
@@ -56,6 +59,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         public void CloneACloneTest()
         {
             var client1 = new OnPremiseClient(AdUrl, AdUsername, AdPassword);
+            Assert.Equal(AuthenticationType.ActiveDirectory, client1.AuthenticationType);
             var response1 = client1.Execute(new WhoAmIRequest()) as WhoAmIResponse;
 
             var client2 = client1.Clone();
@@ -77,6 +81,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         public void CloneTestInTasks()
         {
             var client = new OnPremiseClient(AdUrl, AdUsername, AdPassword);
+            Assert.Equal(AuthenticationType.ActiveDirectory, client.AuthenticationType);
             var response1 = client.Execute(new WhoAmIRequest()) as WhoAmIResponse;
 
             Assert.NotNull(response1);
@@ -138,6 +143,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         public async Task WhoAmIRequestAsyncTest()
         {
             var client = new OnPremiseClient(AdUrl, AdUsername, AdPassword);
+            Assert.Equal(AuthenticationType.ActiveDirectory, client.AuthenticationType);
             var response = (await client.ExecuteAsync(new WhoAmIRequest())) as WhoAmIResponse;
 
             Assert.NotNull(response);
@@ -154,6 +160,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
             var columnValue = Environment.GetEnvironmentVariable("AD_COLUMN_VALUE") ?? throw new Exception("AD_COLUMN_VALUE environment variable is not set");
 
             var client = new OnPremiseClient(AdUrl, AdUsername, AdPassword);
+            Assert.Equal(AuthenticationType.ActiveDirectory, client.AuthenticationType);
 
             var tasks = new Task[10];
 

--- a/Data8.PowerPlatform.Dataverse.Client.Tests/ClaimsBasedAuthClientTests.cs
+++ b/Data8.PowerPlatform.Dataverse.Client.Tests/ClaimsBasedAuthClientTests.cs
@@ -1,7 +1,12 @@
-﻿using Microsoft.Crm.Sdk.Messages;
+﻿using Data8.PowerPlatform.Dataverse.Client.Wsdl;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
 using System;
+using System.Security.Policy;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
+using AuthenticationType = Data8.PowerPlatform.Dataverse.Client.Wsdl.AuthenticationType;
 
 namespace Data8.PowerPlatform.Dataverse.Client.Tests
 {
@@ -13,7 +18,7 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
         private string ClaimsUsername { get; init; }
         private string ClaimsPassword { get; init; }
 
-        internal ClaimsBasedAuthClientTests(ITestOutputHelper output)
+        public ClaimsBasedAuthClientTests(ITestOutputHelper output)
         {
             _output = output;
             //allow all certificates
@@ -24,11 +29,179 @@ namespace Data8.PowerPlatform.Dataverse.Client.Tests
             ClaimsPassword = Environment.GetEnvironmentVariable("CLAIMS_PASSWORD") ?? throw new Exception("CLAIMS_PASSWORD environment variable is not set");
         }
 
+        #region SYNC TESTS 
+
         [Fact]
-        public void ClaimsTest()
+        public void WhoAmIRequestTest()
         {
             var client = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
-            client.Execute(new WhoAmIRequest());
+            Assert.Equal(AuthenticationType.Federation, client.AuthenticationType);
+            var response = client.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+
+            Assert.NotNull(response);
+            Assert.NotEqual(Guid.Empty, response.UserId);
         }
+
+        [Fact]
+        public void CloneTest()
+        {
+            var client = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
+            Assert.Equal(AuthenticationType.Federation, client.AuthenticationType);
+            var response1 = client.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+            var newClient = client.Clone();
+            client = null;
+            var response2 = newClient.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+
+            Assert.NotNull(response1);
+            Assert.NotNull(response2);
+            Assert.Equal(response1.UserId, response2.UserId);
+        }
+
+        [Fact]
+        public void CloneACloneTest()
+        {
+            var client1 = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
+            Assert.Equal(AuthenticationType.Federation, client1.AuthenticationType);
+            var response1 = client1.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+
+            var client2 = client1.Clone();
+            client1 = null;
+            var response2 = client2.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+
+            var client3 = client2.Clone();
+            client2 = null;
+            var response3 = client3.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+
+            Assert.NotNull(response1);
+            Assert.NotNull(response2);
+            Assert.NotNull(response3);
+            Assert.Equal(response1.UserId, response2.UserId);
+            Assert.Equal(response1.UserId, response3.UserId);
+        }
+
+        [Fact]
+        public void CloneTestInTasks()
+        {
+            var client = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
+            Assert.Equal(AuthenticationType.Federation, client.AuthenticationType);
+            var response1 = client.Execute(new WhoAmIRequest()) as WhoAmIResponse;
+
+            Assert.NotNull(response1);
+
+            var tasks = new Task[10];
+
+            for (var i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    var newClient = client.Clone();
+                    var response2 = (WhoAmIResponse)newClient.Execute(new WhoAmIRequest());
+
+                    Assert.Equal(response1.UserId, response2.UserId);
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        [Fact]
+        public void UpdateAndRetrieveInTasksTest()
+        {
+            var entityName = Environment.GetEnvironmentVariable("CLAIMS_ENTITY_NAME") ?? throw new Exception("CLAIMS_ENTITY_NAME environment variable is not set");
+
+            var columnName = Environment.GetEnvironmentVariable("CLAIMS_COLUMN_NAME") ?? throw new Exception("CLAIMS_COLUMN_NAME environment variable is not set");
+            var columnValue = Environment.GetEnvironmentVariable("CLAIMS_COLUMN_VALUE") ?? throw new Exception("CLAIMS_COLUMN_VALUE environment variable is not set");
+
+            var client = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
+
+            var id = client.Create(new Entity(entityName));
+
+            try
+            {
+                var tasks = new Task[10];
+
+                for (var i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = Task.Run(() =>
+                    {
+                        var newClient = client.Clone();
+                        var en = new Entity(entityName, id)
+                        {
+                            [columnName] = columnValue
+                        };
+
+                        newClient.Update(en);
+
+                        var entity = newClient.Retrieve(en.LogicalName, en.Id, new Microsoft.Xrm.Sdk.Query.ColumnSet(columnName));
+                        _output.WriteLine($"{entity[columnName]}");
+                    });
+                }
+
+                Task.WaitAll(tasks);
+            }
+            finally
+            {
+                client.Delete(entityName, id);
+            }
+        }
+
+        #endregion
+
+        #region ASYNC TESTS
+
+        [Fact]
+        public async Task WhoAmIRequestAsyncTest()
+        {
+            var client = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
+            Assert.Equal(AuthenticationType.Federation, client.AuthenticationType);
+            var response = (await client.ExecuteAsync(new WhoAmIRequest())) as WhoAmIResponse;
+
+            Assert.NotNull(response);
+            Assert.NotEqual(Guid.Empty, response.UserId);
+        }
+
+        [Fact]
+        public async void UpdateAndRetrieveAsyncInTasksTest()
+        {
+            var entityName = Environment.GetEnvironmentVariable("CLAIMS_ENTITY_NAME") ?? throw new Exception("CLAIMS_ENTITY_NAME environment variable is not set");
+
+            var columnName = Environment.GetEnvironmentVariable("CLAIMS_COLUMN_NAME") ?? throw new Exception("CLAIMS_COLUMN_NAME environment variable is not set");
+            var columnValue = Environment.GetEnvironmentVariable("CLAIMS_COLUMN_VALUE") ?? throw new Exception("CLAIMS_COLUMN_VALUE environment variable is not set");
+
+            var client = new OnPremiseClient(ClaimsUrl, ClaimsUsername, ClaimsPassword);
+            Assert.Equal(AuthenticationType.Federation, client.AuthenticationType);
+
+            var id = await client.CreateAsync(new Entity(entityName));
+
+            try
+            {
+                var tasks = new Task[10];
+
+                for (var i = 0; i < tasks.Length; i++)
+                {
+                    tasks[i] = Task.Run(async () =>
+                    {
+                        var newClient = client.Clone();
+                        var en = new Entity(entityName, id)
+                        {
+                            [columnName] = columnValue
+                        };
+
+                        await newClient.UpdateAsync(en);
+
+                        var entity = await newClient.RetrieveAsync(en.LogicalName, en.Id, new Microsoft.Xrm.Sdk.Query.ColumnSet(columnName));
+                        _output.WriteLine($"{entity[columnName]}");
+                    });
+                }
+
+                Task.WaitAll(tasks);
+            }
+            finally
+            {
+                await client.DeleteAsync(entityName, id);
+            }
+        }
+
+        #endregion
     }
 }

--- a/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/ClaimsBasedAuthClient.cs
@@ -29,7 +29,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
     /// <summary>
     /// Inner client to set up the SOAP channel using WS-Trust
     /// </summary>
-    class ClaimsBasedAuthClient : ClientBase<IOrganizationServiceAsync2>, IOrganizationServiceAsync2, IInnerOrganizationService
+    class ClaimsBasedAuthClient : ClientBase<IOrganizationService>, IOrganizationServiceAsync2, IInnerOrganizationService
     {
         private readonly ProxySerializationSurrogate _serializationSurrogate;
 
@@ -140,7 +140,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task<Guid> CreateAsync(Entity entity, CancellationToken cancelationToken)
         {
-            return await Channel.CreateAsync(entity);
+            return await Task.Run(() => Create(entity), cancelationToken).ConfigureAwait(false);
         }
 
         public async Task<Entity> CreateAndReturnAsync(Entity entity, CancellationToken cancellationToken)
@@ -156,7 +156,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task<Entity> RetrieveAsync(string entityName, Guid id, ColumnSet columnSet, CancellationToken cancellationToken)
         {
-            return await Channel.RetrieveAsync(entityName, id, columnSet);
+            return await Task.Run(() => Retrieve(entityName, id, columnSet), cancellationToken).ConfigureAwait(false);
         }
 
         public async Task UpdateAsync(Entity entity)
@@ -166,7 +166,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task UpdateAsync(Entity entity, CancellationToken cancelationToken)
         {
-            await Channel.UpdateAsync(entity);
+            await Task.Run(() => Update(entity), cancelationToken).ConfigureAwait(false);
         }
 
         public async Task DeleteAsync(string entityName, Guid id)
@@ -176,7 +176,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task DeleteAsync(string entityName, Guid id, CancellationToken cancelationToken)
         {
-            await Channel.DeleteAsync(entityName, id);
+            await Task.Run(() => Delete(entityName, id), cancelationToken).ConfigureAwait(false);
         }
 
         public async Task<OrganizationResponse> ExecuteAsync(OrganizationRequest request)
@@ -186,7 +186,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task<OrganizationResponse> ExecuteAsync(OrganizationRequest request, CancellationToken cancelationToken)
         {
-            return await Channel.ExecuteAsync(request);
+            return await Task.Run(() => Execute(request), cancelationToken).ConfigureAwait(false);
         }
 
         public async Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
@@ -196,7 +196,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancelationToken)
         {
-            await Channel.AssociateAsync(entityName, entityId, relationship, relatedEntities);
+            await Task.Run(() => Associate(entityName, entityId, relationship, relatedEntities), cancelationToken).ConfigureAwait(false);
         }
 
         public async Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
@@ -206,7 +206,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities, CancellationToken cancelationToken)
         {
-            await Channel.DisassociateAsync(entityName, entityId, relationship, relatedEntities);
+            await Task.Run(() => Disassociate(entityName, entityId, relationship, relatedEntities), cancelationToken).ConfigureAwait(false);
         }
 
         public async Task<EntityCollection> RetrieveMultipleAsync(QueryBase query)
@@ -216,7 +216,7 @@ namespace Data8.PowerPlatform.Dataverse.Client
 
         public async Task<EntityCollection> RetrieveMultipleAsync(QueryBase query, CancellationToken cancellationToken)
         {
-            return await Channel.RetrieveMultipleAsync(query);
+            return await Task.Run(() => RetrieveMultiple(query), cancellationToken).ConfigureAwait(false);
         }
 
         public Guid Create(Entity entity)

--- a/Data8.PowerPlatform.Dataverse.Client/OnPremiseClient.cs
+++ b/Data8.PowerPlatform.Dataverse.Client/OnPremiseClient.cs
@@ -191,6 +191,11 @@ namespace Data8.PowerPlatform.Dataverse.Client
             set => _service.Timeout = value;
         }
 
+        /// <summary>
+        /// The type of authentication used to connect to the organization service
+        /// </summary>
+        public AuthenticationType AuthenticationType => _authenticationType;
+
         private IInnerOrganizationService GetInnerService()
         {
             switch (_authenticationType)


### PR DESCRIPTION
Use sync-over-async for claims based auth client as `ClientBase<T>` doesn't handle generating both sync and async proxies for the same method.